### PR TITLE
Await exponential backoff for unknown state

### DIFF
--- a/src/pulls.ts
+++ b/src/pulls.ts
@@ -75,7 +75,7 @@ export async function listMergeConflictPulls(
           break;
 
         case "unknown":
-          expbackoff(retries + 1);
+          await expbackoff(retries + 1);
           break;
       }
     };


### PR DESCRIPTION
## Description

Now does not wait for pulls with `unknown` state. This causes these pulls not to carry out the following operation.

```
{"status":200,"url":"https://api.github.com/repos/ooo/rrr/pulls/2"}
{"number":2,"mergeable_state":"unknown","pushed_at":"2023-01-05T06:16:15Z"}
pulls = []
done
{"status":200,"url":"https://api.github.com/repos/ooo/rrr/pulls/2"}
{"number":2,"mergeable_state":"dirty","pushed_at":"2023-01-05T06:16:15Z"}
```